### PR TITLE
Hard-code tag 700 (TIFF XMP) as type `BYTE`

### DIFF
--- a/src/tags-helpers.js
+++ b/src/tags-helpers.js
@@ -71,7 +71,11 @@ function readTag(dataView, ifdType, tiffHeaderOffset, offset, byteOrder, include
     const TAG_VALUE_OFFSET = TAG_COUNT_OFFSET + Types.getTypeSize('LONG');
 
     const tagCode = Types.getShortAt(dataView, offset, byteOrder);
-    const tagType = Types.getShortAt(dataView, offset + TAG_TYPE_OFFSET, byteOrder);
+    // This works around a bug in which some imagers declare the XMP
+    // tag (700) in TIFF files as type ASCII instead of type BYTE:
+    const tagType = tagCode === 700
+        ? Types.tagTypes['BYTE']
+        : Types.getShortAt(dataView, offset + TAG_TYPE_OFFSET, byteOrder);
     const tagCount = Types.getLongAt(dataView, offset + TAG_COUNT_OFFSET, byteOrder);
     let tagValue;
 


### PR DESCRIPTION
**🚨 This is a public repository 🚨** 

## What?
This PR hard-codes the tag type for tag 700 (corresponding to the TIFF XMP tag) to `BYTE`.

## Why?
Some imagers erroneously set the XMP tag type to `ASCII`, which is then converted by this library to JavaScript strings rather than being interpreted as XMP XML data.

### References
The [Adobe XMP Specification Part 3](https://github.com/adobe/XMP-Toolkit-SDK/blob/9f779e85f15c92108f8b911930998a152b209491/docs/XMPSpecificationPart3.pdf) calls for this tag type to be set to `BYTE` (or `UNDEFINED` but that seems less encouraged):
![image](https://github.com/user-attachments/assets/6e5325fc-0537-4e99-a0da-20a46b90422d)
